### PR TITLE
Fixed typo in carousel causing compilation error TS2345.

### DIFF
--- a/components/carousel.ts
+++ b/components/carousel.ts
@@ -27,7 +27,7 @@ export interface ICarouselData extends IBaseData {
     interval?: number;
     pauseOn?: CarouselPauseOn;
     wrap?: boolean;
-    keybord?: boolean;
+    keyboard?: boolean;
     onSlide?: () => void;
 }
 
@@ -110,7 +110,7 @@ export const carousel = b.createDerivedComponent<ICarouselData>(elem, {
             interval: ctx.data.interval,
             pause: ctx.data.pauseOn !== undefined ? CarouselPauseOn[ctx.data.pauseOn].toLowerCase() : undefined,
             wrap: ctx.data.wrap,
-            keybord: ctx.data.keybord,
+            keyboard: ctx.data.keyboard,
         });
         jqueryElement.on('slide.bs.carousel', () => {
             ctx.initialSlideChanged = true;


### PR DESCRIPTION
A typo in carousel.ts causing compilation error:

```
Starting compilation.
/Users/mira/Git/project/node_modules/bobrilstrap/components/carousel.ts(109,32): error TS2345: Argument of type '{ interval: number; pause: string; wrap: boolean; keybord: boolean; }' is not assignable to parameter of type 'string'.

Compiled in 2271ms. Found 1 error. Updated 2 files.
Build failed with 1 errors.
```